### PR TITLE
Fix climate entity HVAC mode and coordinator power state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ htmlcov/
 home-assistant.log
 home-assistant_v2.db
 OZW_Log.txt
+.venv-test/

--- a/custom_components/iceco/climate.py
+++ b/custom_components/iceco/climate.py
@@ -52,8 +52,7 @@ class IcecoClimate(CoordinatorEntity[IcecoDataUpdateCoordinator], ClimateEntity)
 
     _attr_has_entity_name = True
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
-    # Only one HVAC mode — fridge always cools. Power on/off via the Power switch.
-    _attr_hvac_modes = [HVACMode.COOL]
+    _attr_hvac_modes = [HVACMode.COOL, HVACMode.OFF]
     _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
     _attr_preset_modes = ["Refrigeration", "Freezing"]
     _attr_min_temp = MIN_TEMP
@@ -106,7 +105,9 @@ class IcecoClimate(CoordinatorEntity[IcecoDataUpdateCoordinator], ClimateEntity)
 
     @property
     def hvac_mode(self) -> HVACMode:
-        """Always cooling — power on/off is the Power switch's job."""
+        """Return COOL when powered on, OFF when powered off."""
+        if not self.coordinator.data.power_on:
+            return HVACMode.OFF
         return HVACMode.COOL
 
     @property
@@ -161,8 +162,11 @@ class IcecoClimate(CoordinatorEntity[IcecoDataUpdateCoordinator], ClimateEntity)
             _LOGGER.error("Failed to set %s zone temperature: %s", self._zone, err)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
-        """No-op — only one HVAC mode supported."""
-        pass
+        """Toggle power to match requested HVAC mode."""
+        if hvac_mode == HVACMode.OFF and self.coordinator.data.power_on:
+            await self.coordinator.async_toggle_power()
+        elif hvac_mode == HVACMode.COOL and not self.coordinator.data.power_on:
+            await self.coordinator.async_toggle_power()
 
     @property
     def available(self) -> bool:

--- a/custom_components/iceco/coordinator.py
+++ b/custom_components/iceco/coordinator.py
@@ -17,7 +17,7 @@ from homeassistant.components import bluetooth
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .iceco_protocol import IcecoClient, IcecoProtocol, IcecoStatus
+from .iceco_protocol import IcecoProtocol, IcecoStatus
 
 from .const import (
     ALARM_HYSTERESIS,
@@ -63,8 +63,9 @@ class IcecoData:
     # ECO mode state (from SECONDARY eco_max field: 1=ECO, 0=MAX)
     eco_mode: Optional[bool] = None  # True=ECO, False=MAX, None=unknown
 
-    # Lock state (from PRIMARY field 5: 2=locked, 1=unlocked)
-    locked: Optional[bool] = None  # True=locked, False=unlocked, None=unknown
+    # Power and lock state (promoted from IcecoStatus for entity access)
+    power_on: Optional[bool] = None  # True=on, False=off, None=unknown
+    locked: Optional[bool] = None    # True=locked, False=unlocked, None=unknown
 
     # Alarm timing tracking
     _left_alarm_start: Optional[datetime] = field(default=None, repr=False)
@@ -182,6 +183,7 @@ class IcecoDataUpdateCoordinator(DataUpdateCoordinator[IcecoData]):
             self.data.status = status
             self.data.left_setpoint = status.left_temp
             self.data.right_setpoint = status.right_temp
+            self.data.power_on = status.power_on
             self.data.locked = status.locked
             self.data.last_update = datetime.now()
             self.data.power_loss_alarm = False


### PR DESCRIPTION
## Summary

- Climate entity `hvac_mode` property now returns `HVACMode.OFF` when the fridge is powered down and `HVACMode.COOL` when on. Previously always returned `COOL` regardless of power state.
- `async_set_hvac_mode` toggles the fridge power to match the requested mode.
- Adds `power_on: Optional[bool]` to `IcecoData` and populates it in `_notification_callback` alongside `locked`. The climate entity was referencing `coordinator.data.power_on` which did not exist on `IcecoData` — only on the nested `IcecoStatus` object.
- Removes unused `IcecoClient` import from `coordinator.py`.
- Adds `.venv-test/` to `.gitignore`.

## Test plan

- [ ] Confirm climate entity shows as unavailable / OFF in HA UI when fridge is powered down
- [ ] Confirm turning HVAC mode OFF from HA sends power toggle and disconnects
- [ ] Confirm turning HVAC mode to COOL from HA reconnects and powers on if needed