### PR TITLE
Add pytest test suite

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,9 @@
+pytest-homeassistant-custom-component
+pytest>=7.0
+pytest-cov
+ruff
+# Transitive dependencies pulled in by HA's bluetooth/USB components at import time.
+# Not declared by pytest-homeassistant-custom-component but required for tests to collect.
+aiousbwatcher
+pyserial
+pyudev

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+# Shared fixtures for the Iceco integration test suite.
+
+from unittest.mock import patch
+
+import pytest
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations: None) -> None:
+    """Enable custom integration loading for all tests in this suite."""
+
+
+@pytest.fixture(autouse=True)
+def patch_bluetooth_history():
+    """Patch bluetooth history loading which relies on D-Bus (Linux only).
+
+    async_load_history_from_system is called during bluetooth component setup.
+    On macOS the dbus code path crashes because BlueZ isn't available,
+    even when mock_bluetooth_adapters is active. Returning empty dicts is
+    correct for a test environment with no real adapters.
+    """
+    with patch(
+        "homeassistant.components.bluetooth.manager.async_load_history_from_system",
+        return_value=({}, {}),
+    ):
+        yield

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,317 @@
+"""Tests for Iceco config flow and options flow."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.iceco.const import (
+    CONF_DEVICE_ADDRESS,
+    CONF_POLL_INTERVAL,
+    CONF_POWER_LOSS_TIMEOUT,
+    CONF_TEMP_DEVIATION_DURATION,
+    CONF_TEMP_DEVIATION_THRESHOLD,
+    DOMAIN,
+)
+
+TEST_ADDRESS = "AA:BB:CC:DD:EE:FF"
+TEST_NAME = "Iceco Fridge"
+
+# Patch target for IcecoClient.identify_device called in the config flow
+_IDENTIFY_PATCH = "custom_components.iceco.config_flow.IcecoClient.identify_device"
+
+
+def _make_bt_discovery(address: str = TEST_ADDRESS, name: str = TEST_NAME):
+    """Build a BluetoothServiceInfoBleak for testing."""
+    return BluetoothServiceInfoBleak(
+        name=name,
+        address=address,
+        rssi=-60,
+        manufacturer_data={},
+        service_data={},
+        service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
+        source="local",
+        device=MagicMock(),
+        advertisement=MagicMock(),
+        connectable=True,
+        time=0.0,
+        tx_power=-127,
+    )
+
+
+def _make_discovered_device(address: str = TEST_ADDRESS, name: str = TEST_NAME):
+    """Build a minimal discovered device for async_discovered_service_info."""
+    device = MagicMock()
+    device.address = address
+    device.name = name
+    device.service_uuids = ["0000fff0-0000-1000-8000-00805f9b34fb"]
+    return device
+
+
+# ---------------------------------------------------------------------------
+# Bluetooth discovery path
+# ---------------------------------------------------------------------------
+
+
+class TestBluetoothDiscovery:
+    async def test_discovery_shows_confirm_form(self, hass, enable_bluetooth):
+        discovery = _make_bt_discovery()
+        with patch(_IDENTIFY_PATCH, new=AsyncMock(side_effect=Exception("no BLE in test"))):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_BLUETOOTH},
+                data=discovery,
+            )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "confirm"
+
+    async def test_discovery_creates_entry_on_confirm(self, hass, enable_bluetooth):
+        discovery = _make_bt_discovery()
+        with patch(_IDENTIFY_PATCH, new=AsyncMock(side_effect=Exception("no BLE in test"))):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_BLUETOOTH},
+                data=discovery,
+            )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={},
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_DEVICE_ADDRESS] == TEST_ADDRESS
+
+    async def test_discovery_duplicate_aborts(self, hass, enable_bluetooth):
+        existing = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_DEVICE_ADDRESS: TEST_ADDRESS},
+            unique_id=TEST_ADDRESS,
+        )
+        existing.add_to_hass(hass)
+
+        discovery = _make_bt_discovery()
+        with patch(_IDENTIFY_PATCH, new=AsyncMock(side_effect=Exception("no BLE in test"))):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_BLUETOOTH},
+                data=discovery,
+            )
+
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "already_configured"
+
+    async def test_discovery_title_uses_device_name(self, hass, enable_bluetooth):
+        discovery = _make_bt_discovery(name="My Iceco")
+        with patch(_IDENTIFY_PATCH, new=AsyncMock(side_effect=Exception("no BLE in test"))):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_BLUETOOTH},
+                data=discovery,
+            )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={},
+        )
+
+        assert result["title"] == "My Iceco"
+
+    async def test_discovery_falls_back_title_when_no_name(self, hass, enable_bluetooth):
+        # BluetoothServiceInfoBleak.name cannot be empty string in newer habluetooth;
+        # test None name via a mock instead
+        discovery = MagicMock(spec=BluetoothServiceInfoBleak)
+        discovery.address = TEST_ADDRESS
+        discovery.name = None
+        with patch(_IDENTIFY_PATCH, new=AsyncMock(side_effect=Exception("no BLE in test"))):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_BLUETOOTH},
+                data=discovery,
+            )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={},
+        )
+
+        assert result["title"] == "Iceco Refrigerator"
+
+
+# ---------------------------------------------------------------------------
+# Manual user path — no devices found
+# ---------------------------------------------------------------------------
+
+
+class TestManualFlowNoDevices:
+    async def test_shows_manual_entry_form_when_no_devices(self, hass, enable_bluetooth):
+        with patch(
+            "custom_components.iceco.config_flow.async_discovered_service_info",
+            return_value=[],
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_USER},
+            )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+    async def test_manual_entry_cannot_connect_shows_error(self, hass, enable_bluetooth):
+        with patch(
+            "custom_components.iceco.config_flow.async_discovered_service_info",
+            return_value=[],
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_USER},
+            )
+
+        with patch(_IDENTIFY_PATCH, new=AsyncMock(side_effect=Exception("connection failed"))):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={"address": TEST_ADDRESS},
+            )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["errors"] == {"base": "cannot_connect"}
+
+    async def test_manual_entry_creates_entry_on_success(self, hass, enable_bluetooth):
+        with patch(
+            "custom_components.iceco.config_flow.async_discovered_service_info",
+            return_value=[],
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_USER},
+            )
+
+        with patch(
+            _IDENTIFY_PATCH,
+            new=AsyncMock(return_value={"left_temp": -18, "right_temp": -15}),
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={"address": TEST_ADDRESS},
+            )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_DEVICE_ADDRESS] == TEST_ADDRESS
+
+
+# ---------------------------------------------------------------------------
+# Manual user path — devices found (select_device step)
+# ---------------------------------------------------------------------------
+
+
+class TestManualFlowWithDevices:
+    async def test_shows_select_device_form_when_devices_found(
+        self, hass, enable_bluetooth
+    ):
+        fake_device = _make_discovered_device()
+        with patch(
+            "custom_components.iceco.config_flow.async_discovered_service_info",
+            return_value=[fake_device],
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_USER},
+            )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "select_device"
+
+    async def test_select_device_creates_entry(self, hass, enable_bluetooth):
+        fake_device = _make_discovered_device()
+        with patch(
+            "custom_components.iceco.config_flow.async_discovered_service_info",
+            return_value=[fake_device],
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_USER},
+            )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"address": TEST_ADDRESS},
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_DEVICE_ADDRESS] == TEST_ADDRESS
+
+    async def test_select_device_duplicate_aborts(self, hass, enable_bluetooth):
+        existing = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_DEVICE_ADDRESS: TEST_ADDRESS},
+            unique_id=TEST_ADDRESS,
+        )
+        existing.add_to_hass(hass)
+
+        fake_device = _make_discovered_device()
+        with patch(
+            "custom_components.iceco.config_flow.async_discovered_service_info",
+            return_value=[fake_device],
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_USER},
+            )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"address": TEST_ADDRESS},
+        )
+
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "already_configured"
+
+
+# ---------------------------------------------------------------------------
+# Options flow
+# ---------------------------------------------------------------------------
+
+
+class TestOptionsFlow:
+    async def test_options_flow_shows_init_form(self, hass, enable_bluetooth):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_DEVICE_ADDRESS: TEST_ADDRESS},
+            unique_id=TEST_ADDRESS,
+            options={},
+        )
+        entry.add_to_hass(hass)
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "init"
+
+    async def test_options_flow_saves_values(self, hass, enable_bluetooth):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_DEVICE_ADDRESS: TEST_ADDRESS},
+            unique_id=TEST_ADDRESS,
+            options={},
+        )
+        entry.add_to_hass(hass)
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_POLL_INTERVAL: 90,
+                CONF_POWER_LOSS_TIMEOUT: 20,
+                CONF_TEMP_DEVIATION_THRESHOLD: 4,
+                CONF_TEMP_DEVIATION_DURATION: 10,
+            },
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_POLL_INTERVAL] == 90
+        assert result["data"][CONF_POWER_LOSS_TIMEOUT] == 20

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,352 @@
+"""Tests for IcecoDataUpdateCoordinator notification processing and alarm logic.
+
+BLE client calls are mocked — no hardware required.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.iceco.const import (
+    CONF_POWER_LOSS_TIMEOUT,
+    CONF_TEMP_DEVIATION_DURATION,
+    CONF_TEMP_DEVIATION_THRESHOLD,
+    DEFAULT_POLL_INTERVAL,
+    DEFAULT_POWER_LOSS_TIMEOUT,
+    DEFAULT_TEMP_DEVIATION_DURATION,
+    DEFAULT_TEMP_DEVIATION_THRESHOLD,
+)
+from custom_components.iceco.coordinator import IcecoData, IcecoDataUpdateCoordinator
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TEST_ADDRESS = "AA:BB:CC:DD:EE:FF"
+
+
+def _make_entry(address: str = TEST_ADDRESS, options: dict | None = None):
+    entry = MagicMock()
+    entry.data = {"device_address": address}
+    entry.options = options or {}
+    entry.entry_id = "test_entry_id"
+    return entry
+
+
+def _make_hass(entry=None):
+    hass = MagicMock()
+    hass.config_entries.async_get_entry.return_value = entry or _make_entry()
+    return hass
+
+
+def _make_coord(address: str = TEST_ADDRESS, options: dict | None = None):
+    entry = _make_entry(address, options)
+    hass = _make_hass(entry)
+    ble_device = MagicMock()
+    ble_device.address = address
+    coord = IcecoDataUpdateCoordinator(hass, ble_device, entry.entry_id)
+    # Suppress HA coordinator machinery — we're testing data logic only
+    coord.async_set_updated_data = MagicMock()
+    return coord
+
+
+# Raw notification bytes
+PRIMARY_ON_UNLOCKED = b",-18,-15,1,126,1\n"   # power_status=1: on, unlocked
+PRIMARY_ON_LOCKED = b",-18,-15,1,126,2\n"      # power_status=2: on, locked
+PRIMARY_OFF = b",-18,-15,1,126,0\n"            # power_status=0: off
+PRIMARY_POSITIVE = b",4,0,2,130,1\n"           # positive setpoints, 13.0V
+SECONDARY_CELSIUS = b"/S00/U/2,1,1,-15,-12\n"  # ECO on, Celsius current temps
+SECONDARY_FAHRENHEIT = b"/S00/U/2,0,2,14,32\n" # MAX mode, Fahrenheit current temps
+SECONDARY_MAX = b"/S00/U/2,0,1,-15,-12\n"      # MAX mode, Celsius
+
+
+# ---------------------------------------------------------------------------
+# PRIMARY notification processing
+# ---------------------------------------------------------------------------
+
+
+class TestPrimaryNotification:
+    def test_sets_left_setpoint(self):
+        coord = _make_coord()
+        coord._notification_callback(0, PRIMARY_ON_UNLOCKED)
+        assert coord.data.left_setpoint == -18
+
+    def test_sets_right_setpoint(self):
+        coord = _make_coord()
+        coord._notification_callback(0, PRIMARY_ON_UNLOCKED)
+        assert coord.data.right_setpoint == -15
+
+    def test_power_status_1_is_on(self):
+        coord = _make_coord()
+        coord._notification_callback(0, PRIMARY_ON_UNLOCKED)
+        assert coord.data.power_on is True
+
+    def test_power_status_2_is_on(self):
+        coord = _make_coord()
+        coord._notification_callback(0, PRIMARY_ON_LOCKED)
+        assert coord.data.power_on is True
+
+    def test_power_status_0_is_off(self):
+        coord = _make_coord()
+        coord._notification_callback(0, PRIMARY_OFF)
+        assert coord.data.power_on is False
+
+    def test_power_status_2_sets_locked(self):
+        coord = _make_coord()
+        coord._notification_callback(0, PRIMARY_ON_LOCKED)
+        assert coord.data.locked is True
+
+    def test_power_status_1_is_unlocked(self):
+        coord = _make_coord()
+        coord._notification_callback(0, PRIMARY_ON_UNLOCKED)
+        assert coord.data.locked is False
+
+    def test_battery_voltage_decoded(self):
+        coord = _make_coord()
+        coord._notification_callback(0, PRIMARY_ON_UNLOCKED)
+        assert coord.data.status.battery_voltage == pytest.approx(12.6)
+
+    def test_clears_power_loss_alarm(self):
+        coord = _make_coord()
+        coord.data.power_loss_alarm = True
+        coord._notification_callback(0, PRIMARY_ON_UNLOCKED)
+        assert coord.data.power_loss_alarm is False
+
+    def test_sets_last_update(self):
+        coord = _make_coord()
+        before = datetime.now()
+        coord._notification_callback(0, PRIMARY_ON_UNLOCKED)
+        assert coord.data.last_update >= before
+
+    def test_triggers_ha_update(self):
+        coord = _make_coord()
+        coord._notification_callback(0, PRIMARY_ON_UNLOCKED)
+        coord.async_set_updated_data.assert_called_once()
+
+    def test_positive_setpoints(self):
+        coord = _make_coord()
+        coord._notification_callback(0, PRIMARY_POSITIVE)
+        assert coord.data.left_setpoint == 4
+        assert coord.data.right_setpoint == 0
+
+
+# ---------------------------------------------------------------------------
+# SECONDARY notification processing
+# ---------------------------------------------------------------------------
+
+
+class TestSecondaryNotification:
+    def test_sets_left_current_temp_celsius(self):
+        coord = _make_coord()
+        coord._notification_callback(0, SECONDARY_CELSIUS)
+        assert coord.data.left_current_temp == -15
+
+    def test_sets_right_current_temp_celsius(self):
+        coord = _make_coord()
+        coord._notification_callback(0, SECONDARY_CELSIUS)
+        assert coord.data.right_current_temp == -12
+
+    def test_fahrenheit_converts_left_to_celsius(self):
+        # 14°F → (14-32)*5/9 = -10°C
+        coord = _make_coord()
+        coord._notification_callback(0, SECONDARY_FAHRENHEIT)
+        assert coord.data.left_current_temp == -10
+
+    def test_fahrenheit_converts_right_to_celsius(self):
+        # 32°F → 0°C
+        coord = _make_coord()
+        coord._notification_callback(0, SECONDARY_FAHRENHEIT)
+        assert coord.data.right_current_temp == 0
+
+    def test_eco_max_1_means_eco_mode_true(self):
+        # eco_max=1 in SECONDARY → ECO mode is active
+        coord = _make_coord()
+        coord._notification_callback(0, SECONDARY_CELSIUS)
+        assert coord.data.eco_mode is True
+
+    def test_eco_max_0_means_eco_mode_false(self):
+        # eco_max=0 → MAX mode
+        coord = _make_coord()
+        coord._notification_callback(0, SECONDARY_MAX)
+        assert coord.data.eco_mode is False
+
+    def test_unit_mode_celsius(self):
+        coord = _make_coord()
+        coord._notification_callback(0, SECONDARY_CELSIUS)
+        assert coord.data.unit_mode == "C"
+
+    def test_unit_mode_fahrenheit(self):
+        coord = _make_coord()
+        coord._notification_callback(0, SECONDARY_FAHRENHEIT)
+        assert coord.data.unit_mode == "F"
+
+    def test_triggers_ha_update(self):
+        coord = _make_coord()
+        coord._notification_callback(0, SECONDARY_CELSIUS)
+        coord.async_set_updated_data.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Unknown / malformed notifications
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownNotification:
+    def test_garbage_data_does_not_update(self):
+        coord = _make_coord()
+        coord._notification_callback(0, b"garbage\n")
+        coord.async_set_updated_data.assert_not_called()
+
+    def test_empty_bytes_does_not_raise(self):
+        coord = _make_coord()
+        coord._notification_callback(0, b"")
+        coord.async_set_updated_data.assert_not_called()
+
+    def test_non_ascii_does_not_raise(self):
+        coord = _make_coord()
+        coord._notification_callback(0, b"\xff\xfe\xfd")
+        coord.async_set_updated_data.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Temperature alarm logic
+# ---------------------------------------------------------------------------
+
+
+class TestZoneAlarm:
+    def test_no_alarm_without_current_temp(self):
+        coord = _make_coord()
+        coord.data.left_setpoint = -18
+        # left_current_temp is None
+        assert coord._check_zone_alarm("left") is False
+
+    def test_no_alarm_without_setpoint(self):
+        coord = _make_coord()
+        coord.data.left_current_temp = -10
+        # left_setpoint is None
+        assert coord._check_zone_alarm("left") is False
+
+    def test_no_alarm_within_threshold(self):
+        coord = _make_coord()
+        coord.data.left_current_temp = -15
+        coord.data.left_setpoint = -18  # deviation=3, threshold=5
+        assert coord._check_zone_alarm("left") is False
+
+    def test_no_alarm_immediately_when_threshold_exceeded(self):
+        # First observation above threshold starts the timer but does not alarm yet
+        coord = _make_coord()
+        coord.data.left_current_temp = -10
+        coord.data.left_setpoint = -18  # deviation=8 > threshold=5
+        result = coord._check_zone_alarm("left")
+        assert result is False
+        assert coord.data._left_alarm_start is not None
+
+    def test_alarm_fires_after_duration(self):
+        coord = _make_coord(options={
+            CONF_TEMP_DEVIATION_THRESHOLD: DEFAULT_TEMP_DEVIATION_THRESHOLD,
+            CONF_TEMP_DEVIATION_DURATION: DEFAULT_TEMP_DEVIATION_DURATION,
+        })
+        coord.data.left_current_temp = -10
+        coord.data.left_setpoint = -18  # deviation=8 > threshold=5
+        # Simulate alarm_start exceeding duration threshold
+        coord.data._left_alarm_start = datetime.now() - timedelta(
+            minutes=DEFAULT_TEMP_DEVIATION_DURATION + 1
+        )
+        assert coord._check_zone_alarm("left") is True
+
+    def test_alarm_does_not_fire_before_duration(self):
+        coord = _make_coord(options={
+            CONF_TEMP_DEVIATION_THRESHOLD: DEFAULT_TEMP_DEVIATION_THRESHOLD,
+            CONF_TEMP_DEVIATION_DURATION: DEFAULT_TEMP_DEVIATION_DURATION,
+        })
+        coord.data.left_current_temp = -10
+        coord.data.left_setpoint = -18
+        # alarm_start less than duration threshold ago
+        coord.data._left_alarm_start = datetime.now() - timedelta(
+            minutes=DEFAULT_TEMP_DEVIATION_DURATION - 1
+        )
+        assert coord._check_zone_alarm("left") is False
+
+    def test_alarm_clears_when_back_within_threshold(self):
+        coord = _make_coord()
+        coord.data.left_current_temp = -18
+        coord.data.left_setpoint = -18  # deviation=0
+        coord.data.left_temp_alarm = True
+        result = coord._check_zone_alarm("left")
+        assert result is False
+        assert coord.data._left_alarm_start is None
+
+    def test_hysteresis_prevents_clear_near_threshold(self):
+        # Alarm was active; deviation=4, effective clear threshold=5-2=3.
+        # 4 > 3, so alarm should stay active.
+        coord = _make_coord(options={CONF_TEMP_DEVIATION_THRESHOLD: 5})
+        coord.data.left_current_temp = -14
+        coord.data.left_setpoint = -18  # deviation=4
+        coord.data.left_temp_alarm = True
+        coord.data._left_alarm_start = datetime.now() - timedelta(
+            minutes=DEFAULT_TEMP_DEVIATION_DURATION + 1
+        )
+        assert coord._check_zone_alarm("left") is True
+
+    def test_hysteresis_allows_clear_below_effective_threshold(self):
+        # Alarm was active; deviation=2, effective clear threshold=5-2=3.
+        # 2 <= 3, so alarm should clear.
+        coord = _make_coord(options={CONF_TEMP_DEVIATION_THRESHOLD: 5})
+        coord.data.left_current_temp = -16
+        coord.data.left_setpoint = -18  # deviation=2
+        coord.data.left_temp_alarm = True
+        assert coord._check_zone_alarm("left") is False
+
+    def test_right_zone_alarm(self):
+        coord = _make_coord(options={
+            CONF_TEMP_DEVIATION_THRESHOLD: DEFAULT_TEMP_DEVIATION_THRESHOLD,
+            CONF_TEMP_DEVIATION_DURATION: DEFAULT_TEMP_DEVIATION_DURATION,
+        })
+        coord.data.right_current_temp = -5
+        coord.data.right_setpoint = -18  # deviation=13 > threshold=5
+        coord.data._right_alarm_start = datetime.now() - timedelta(
+            minutes=DEFAULT_TEMP_DEVIATION_DURATION + 1
+        )
+        assert coord._check_zone_alarm("right") is True
+
+
+# ---------------------------------------------------------------------------
+# Power loss detection
+# ---------------------------------------------------------------------------
+
+
+class TestPowerLossAlarm:
+    async def test_power_loss_alarm_triggers_after_timeout(self):
+        coord = _make_coord(options={CONF_POWER_LOSS_TIMEOUT: DEFAULT_POWER_LOSS_TIMEOUT})
+        coord.data.last_update = datetime.now() - timedelta(
+            minutes=DEFAULT_POWER_LOSS_TIMEOUT + 1
+        )
+        # Keep connection_state as "reconnecting" to avoid triggering reconnect logic
+        coord.data.connection_state = "reconnecting"
+
+        await coord._async_update_data()
+
+        assert coord.data.power_loss_alarm is True
+
+    async def test_power_loss_alarm_clears_when_recent_update(self):
+        coord = _make_coord(options={CONF_POWER_LOSS_TIMEOUT: DEFAULT_POWER_LOSS_TIMEOUT})
+        coord.data.last_update = datetime.now() - timedelta(minutes=1)
+        coord.data.power_loss_alarm = True
+        coord.data.connection_state = "reconnecting"
+
+        await coord._async_update_data()
+
+        assert coord.data.power_loss_alarm is False
+
+    async def test_no_alarm_without_last_update(self):
+        coord = _make_coord()
+        coord.data.last_update = None
+
+        await coord._async_update_data()
+
+        # No last_update means the check is skipped entirely
+        assert coord.data.power_loss_alarm is False

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,85 @@
+"""Tests for Iceco integration setup and unload lifecycle."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.config_entries import ConfigEntryState
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.iceco.const import CONF_DEVICE_ADDRESS, DOMAIN
+
+TEST_ADDRESS = "AA:BB:CC:DD:EE:FF"
+
+
+@pytest.fixture
+def mock_config_entry():
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_DEVICE_ADDRESS: TEST_ADDRESS},
+        unique_id=TEST_ADDRESS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Setup failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestSetupEntry:
+    async def test_setup_raises_config_entry_not_ready_when_no_ble_device(
+        self, hass, mock_config_entry
+    ):
+        mock_config_entry.add_to_hass(hass)
+
+        with patch(
+            "custom_components.iceco.bluetooth.async_ble_device_from_address",
+            return_value=None,
+        ):
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+        assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+
+    async def test_setup_raises_config_entry_not_ready_when_coordinator_fails(
+        self, hass, mock_config_entry
+    ):
+        mock_config_entry.add_to_hass(hass)
+
+        mock_ble_device = MagicMock()
+        mock_ble_device.address = TEST_ADDRESS
+
+        with patch(
+            "custom_components.iceco.bluetooth.async_ble_device_from_address",
+            return_value=mock_ble_device,
+        ), patch(
+            "custom_components.iceco.IcecoDataUpdateCoordinator"
+        ) as mock_coord_cls:
+            mock_coord = MagicMock()
+            mock_coord.async_config_entry_first_refresh = AsyncMock(
+                side_effect=Exception("BLE connection failed")
+            )
+            mock_coord_cls.return_value = mock_coord
+
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+        assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+
+
+# ---------------------------------------------------------------------------
+# Unload
+# ---------------------------------------------------------------------------
+
+
+class TestUnloadEntry:
+    async def test_unload_not_loaded_entry_is_safe(self, hass, mock_config_entry):
+        # An entry that was never loaded (e.g. failed with SETUP_RETRY) can be
+        # unloaded without error. HA returns False in this case.
+        mock_config_entry.add_to_hass(hass)
+
+        result = await hass.config_entries.async_unload(mock_config_entry.entry_id)
+
+        assert mock_config_entry.state == ConfigEntryState.NOT_LOADED
+        # HA returns True when unloading an entry that was never loaded (no-op)
+        assert result is True

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,243 @@
+"""Tests for IcecoProtocol command builders and notification parsers.
+
+No Home Assistant dependencies — pure protocol logic only.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.iceco.iceco_protocol.protocol import IcecoProtocol, IcecoStatus
+
+
+# ---------------------------------------------------------------------------
+# Command builder tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCommand:
+    def test_format(self):
+        result = IcecoProtocol.build_command("03", "-18")
+        assert result == b"/S03/1/-18\n"
+
+    def test_returns_bytes(self):
+        result = IcecoProtocol.build_command("00", "-01")
+        assert isinstance(result, bytes)
+
+    def test_ascii_encoding(self):
+        result = IcecoProtocol.build_command("05", "010")
+        result.decode("ascii")  # should not raise
+
+
+class TestSetTemperature:
+    def test_negative_temperature_left(self):
+        # -18°C should format as "-18"
+        assert IcecoProtocol.set_left_temperature(-18) == b"/S03/1/-18\n"
+
+    def test_negative_single_digit_left(self):
+        # -5°C should format as "-05"
+        assert IcecoProtocol.set_left_temperature(-5) == b"/S03/1/-05\n"
+
+    def test_positive_temperature_left(self):
+        # 4°C should format as "004"
+        assert IcecoProtocol.set_left_temperature(4) == b"/S03/1/004\n"
+
+    def test_zero_temperature_left(self):
+        assert IcecoProtocol.set_left_temperature(0) == b"/S03/1/000\n"
+
+    def test_max_temperature_left(self):
+        # 10°C (MAX_TEMP) should format as "010"
+        assert IcecoProtocol.set_left_temperature(10) == b"/S03/1/010\n"
+
+    def test_min_temperature_left(self):
+        # -22°C (MIN_TEMP) should format as "-22"
+        assert IcecoProtocol.set_left_temperature(-22) == b"/S03/1/-22\n"
+
+    def test_negative_temperature_right(self):
+        assert IcecoProtocol.set_right_temperature(-15) == b"/S05/1/-15\n"
+
+    def test_positive_temperature_right(self):
+        assert IcecoProtocol.set_right_temperature(4) == b"/S05/1/004\n"
+
+    def test_left_uses_s03(self):
+        cmd = IcecoProtocol.set_left_temperature(-10)
+        assert b"/S03/" in cmd
+
+    def test_right_uses_s05(self):
+        cmd = IcecoProtocol.set_right_temperature(-10)
+        assert b"/S05/" in cmd
+
+
+class TestTogglePower:
+    def test_format(self):
+        assert IcecoProtocol.toggle_power() == b"/S00/1/-01\n"
+
+    def test_always_same_command(self):
+        # Power is a toggle — same command for on and off
+        assert IcecoProtocol.toggle_power() == IcecoProtocol.toggle_power()
+
+
+class TestSetEcoMode:
+    def test_eco_on(self):
+        assert IcecoProtocol.set_eco_mode(True) == b"/S01/1/001\n"
+
+    def test_eco_off_max_mode(self):
+        assert IcecoProtocol.set_eco_mode(False) == b"/S01/1/000\n"
+
+
+class TestSetLock:
+    def test_lock(self):
+        assert IcecoProtocol.set_lock(True) == b"/S06/1/002\n"
+
+    def test_unlock(self):
+        assert IcecoProtocol.set_lock(False) == b"/S06/1/001\n"
+
+
+# ---------------------------------------------------------------------------
+# PRIMARY notification parser tests
+# ---------------------------------------------------------------------------
+
+
+# Valid PRIMARY: ,<L_setpoint>,<R_setpoint>,<batt_protect>,<voltage_x10>,<power_status>
+PRIMARY_BASIC = b",-18,-15,1,126,1\n"
+PRIMARY_LOCKED = b",-18,-15,1,126,2\n"
+PRIMARY_OFF = b",-18,-15,1,126,0\n"
+PRIMARY_POSITIVE = b",4,0,2,130,1\n"
+
+
+class TestParseNotification:
+    def test_returns_iceco_status(self):
+        result = IcecoProtocol.parse_notification(PRIMARY_BASIC)
+        assert isinstance(result, IcecoStatus)
+
+    def test_left_setpoint(self):
+        result = IcecoProtocol.parse_notification(PRIMARY_BASIC)
+        assert result.left_temp == -18
+
+    def test_right_setpoint(self):
+        result = IcecoProtocol.parse_notification(PRIMARY_BASIC)
+        assert result.right_temp == -15
+
+    def test_battery_protection_level(self):
+        result = IcecoProtocol.parse_notification(PRIMARY_BASIC)
+        assert result.battery_protection_level == 1
+
+    def test_battery_voltage(self):
+        # 126 → 12.6V
+        result = IcecoProtocol.parse_notification(PRIMARY_BASIC)
+        assert result.battery_voltage == pytest.approx(12.6)
+
+    def test_power_status_1_is_on_and_unlocked(self):
+        result = IcecoProtocol.parse_notification(PRIMARY_BASIC)
+        assert result.power_on is True
+        assert result.locked is False
+
+    def test_power_status_2_is_on_and_locked(self):
+        result = IcecoProtocol.parse_notification(PRIMARY_LOCKED)
+        assert result.power_on is True
+        assert result.locked is True
+
+    def test_power_status_0_is_off(self):
+        result = IcecoProtocol.parse_notification(PRIMARY_OFF)
+        assert result.power_on is False
+        assert result.locked is False
+
+    def test_positive_setpoints(self):
+        result = IcecoProtocol.parse_notification(PRIMARY_POSITIVE)
+        assert result.left_temp == 4
+        assert result.right_temp == 0
+
+    def test_returns_none_for_secondary(self):
+        result = IcecoProtocol.parse_notification(b"/S00/U/2,1,1,-15,-12\n")
+        assert result is None
+
+    def test_returns_none_for_wrong_field_count(self):
+        result = IcecoProtocol.parse_notification(b",-18,-15,1,126\n")  # only 4 fields
+        assert result is None
+
+    def test_returns_none_for_non_ascii(self):
+        result = IcecoProtocol.parse_notification(b"\xff\xfe\xfd")
+        assert result is None
+
+    def test_returns_none_for_malformed_integers(self):
+        result = IcecoProtocol.parse_notification(b",-18,abc,1,126,1\n")
+        assert result is None
+
+    def test_returns_none_for_empty(self):
+        result = IcecoProtocol.parse_notification(b"")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# SECONDARY notification parser tests
+# ---------------------------------------------------------------------------
+
+
+# Valid SECONDARY: /S00/U/<zones>,<eco_max>,<unit_mode>,<L_temp>,<R_temp>
+SECONDARY_CELSIUS = b"/S00/U/2,1,1,-15,-12\n"   # ECO on, Celsius
+SECONDARY_FAHRENHEIT = b"/S00/U/2,0,2,14,32\n"   # MAX mode, Fahrenheit
+SECONDARY_SINGLE_ZONE = b"/S00/U/1,0,1,-10,-10\n"
+
+
+class TestParseSecondaryStatus:
+    def test_returns_dict(self):
+        result = IcecoProtocol.parse_secondary_status(SECONDARY_CELSIUS)
+        assert isinstance(result, dict)
+
+    def test_left_temp_celsius(self):
+        result = IcecoProtocol.parse_secondary_status(SECONDARY_CELSIUS)
+        assert result["left_setpoint"] == -15
+
+    def test_right_temp_celsius(self):
+        result = IcecoProtocol.parse_secondary_status(SECONDARY_CELSIUS)
+        assert result["right_setpoint"] == -12
+
+    def test_unit_mode_celsius(self):
+        result = IcecoProtocol.parse_secondary_status(SECONDARY_CELSIUS)
+        assert result["unit_mode"] == 1
+
+    def test_unit_mode_fahrenheit(self):
+        result = IcecoProtocol.parse_secondary_status(SECONDARY_FAHRENHEIT)
+        assert result["unit_mode"] == 2
+
+    def test_eco_max_1_means_eco_on(self):
+        # eco_max=1 in SECONDARY means ECO mode is active
+        result = IcecoProtocol.parse_secondary_status(SECONDARY_CELSIUS)
+        assert result["eco_max"] == 1
+
+    def test_eco_max_0_means_max_mode(self):
+        result = IcecoProtocol.parse_secondary_status(SECONDARY_FAHRENHEIT)
+        assert result["eco_max"] == 0
+
+    def test_zone_count_dual(self):
+        result = IcecoProtocol.parse_secondary_status(SECONDARY_CELSIUS)
+        assert result["zone_count"] == 2
+
+    def test_zone_count_single(self):
+        result = IcecoProtocol.parse_secondary_status(SECONDARY_SINGLE_ZONE)
+        assert result["zone_count"] == 1
+
+    def test_fahrenheit_temps(self):
+        result = IcecoProtocol.parse_secondary_status(SECONDARY_FAHRENHEIT)
+        assert result["left_setpoint"] == 14
+        assert result["right_setpoint"] == 32
+
+    def test_returns_none_for_primary(self):
+        result = IcecoProtocol.parse_secondary_status(b",-18,-15,1,126,1\n")
+        assert result is None
+
+    def test_returns_none_for_wrong_prefix(self):
+        result = IcecoProtocol.parse_secondary_status(b"/S01/U/2,1,1,-15,-12\n")
+        assert result is None
+
+    def test_returns_none_for_too_few_fields(self):
+        result = IcecoProtocol.parse_secondary_status(b"/S00/U/2,1,1,-15\n")  # missing right
+        assert result is None
+
+    def test_returns_none_for_non_ascii(self):
+        result = IcecoProtocol.parse_secondary_status(b"\xff\xfe")
+        assert result is None
+
+    def test_returns_none_for_empty(self):
+        result = IcecoProtocol.parse_secondary_status(b"")
+        assert result is None


### PR DESCRIPTION
## Summary

- Sets up `pytest-homeassistant-custom-component` with `pytest.ini` (`asyncio_mode = auto`) and `requirements_test.txt` (includes `aiousbwatcher`, `pyserial`, `pyudev` as explicit transitive deps required for collection)
- 101 tests across four files, all passing

**test_protocol.py** (48 tests) — pure Python, no HA dependency
- Command builders: `set_left/right_temperature`, `toggle_power`, `set_eco_mode`, `set_lock`
- PRIMARY notification parser: setpoints, battery voltage, power_status encoding (0=off, 1=on+unlocked, 2=on+locked)
- SECONDARY notification parser: current temps, eco_max direction (1=ECO, 0=MAX), unit_mode, zone_count
- Edge cases: malformed, wrong field count, wrong prefix, non-ASCII

**test_coordinator.py** (37 tests) — MagicMock hass, no BLE hardware
- PRIMARY notification processing: setpoints, power_on, locked, battery voltage, last_update, power_loss_alarm reset
- SECONDARY notification processing: Celsius and Fahrenheit→Celsius conversion, eco_mode mapping, unit_mode
- Unknown notifications silently ignored
- Temperature alarm hysteresis: no immediate alarm, fires after duration, clears with hysteresis
- Power loss alarm: triggers after timeout, clears on recent update

**test_config_flow.py** (13 tests) — full HA hass fixture with `enable_bluetooth`
- BT discovery path: shows confirm form, creates entry, aborts on duplicate, title handling
- Manual path (no devices): shows form, reports `cannot_connect` on failure, creates entry on success
- Manual path (devices found): shows select_device form, creates entry, aborts on duplicate
- Options flow: shows init form, saves updated values

**test_init.py** (3 tests)
- Setup raises `ConfigEntryNotReady` when BLE device not found
- Setup raises `ConfigEntryNotReady` when coordinator first refresh fails
- Unloading a not-loaded entry is safe

`conftest.py` patches `bluetooth.manager.async_load_history_from_system` to prevent a dbus/BlueZ crash on macOS during bluetooth component setup.

## Test plan

- [ ] Run `pip install -r requirements_test.txt && pytest tests/` — all 101 should pass