### PR TITLE
Extract shared DeviceInfo to build_device_info helper

### DIFF
--- a/custom_components/iceco/binary_sensor.py
+++ b/custom_components/iceco/binary_sensor.py
@@ -10,7 +10,6 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -32,6 +31,7 @@ from .const import (
     ENTITY_TEMP_ALARM_RIGHT,
 )
 from .coordinator import IcecoDataUpdateCoordinator
+from .helpers import build_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,13 +73,7 @@ class IcecoPowerLossAlarm(
         self._attr_name = "Power Loss Alarm"
         self._entry = entry
 
-        # Device info
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.data[CONF_DEVICE_ADDRESS])},
-            name="Iceco Refrigerator",
-            manufacturer="Iceco",
-            model="Dual Zone Refrigerator",
-        )
+        self._attr_device_info = build_device_info(entry.data[CONF_DEVICE_ADDRESS])
 
     @property
     def is_on(self) -> bool:
@@ -129,13 +123,7 @@ class IcecoTempAlarm(CoordinatorEntity[IcecoDataUpdateCoordinator], BinarySensor
         self._attr_unique_id = f"{entry.data[CONF_DEVICE_ADDRESS]}_{entity_id}"
         self._attr_name = f"{zone.capitalize()} Zone Temperature Alarm"
 
-        # Device info
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.data[CONF_DEVICE_ADDRESS])},
-            name="Iceco Refrigerator",
-            manufacturer="Iceco",
-            model="Dual Zone Refrigerator",
-        )
+        self._attr_device_info = build_device_info(entry.data[CONF_DEVICE_ADDRESS])
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/iceco/climate.py
+++ b/custom_components/iceco/climate.py
@@ -12,7 +12,6 @@ from homeassistant.components.climate import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -27,6 +26,7 @@ from .const import (
     TEMP_STEP,
 )
 from .coordinator import IcecoDataUpdateCoordinator
+from .helpers import build_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -75,13 +75,7 @@ class IcecoClimate(CoordinatorEntity[IcecoDataUpdateCoordinator], ClimateEntity)
         )
         self._attr_name = f"{zone.capitalize()} Zone"
 
-        # Device info
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.data[CONF_DEVICE_ADDRESS])},
-            name="Iceco Refrigerator",
-            manufacturer="Iceco",
-            model="Dual Zone Refrigerator",
-        )
+        self._attr_device_info = build_device_info(entry.data[CONF_DEVICE_ADDRESS])
 
     @property
     def current_temperature(self) -> float | None:

--- a/custom_components/iceco/helpers.py
+++ b/custom_components/iceco/helpers.py
@@ -1,0 +1,16 @@
+"""Shared helpers for Iceco integration entities."""
+from __future__ import annotations
+
+from homeassistant.helpers.entity import DeviceInfo
+
+from .const import DOMAIN
+
+
+def build_device_info(address: str) -> DeviceInfo:
+    """Return DeviceInfo for an Iceco device identified by BLE address."""
+    return DeviceInfo(
+        identifiers={(DOMAIN, address)},
+        name="Iceco Refrigerator",
+        manufacturer="Iceco",
+        model="Dual Zone Refrigerator",
+    )

--- a/custom_components/iceco/sensor.py
+++ b/custom_components/iceco/sensor.py
@@ -12,7 +12,6 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfElectricPotential
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -23,6 +22,7 @@ from .const import (
     ENTITY_BATTERY_VOLTAGE,
 )
 from .coordinator import IcecoDataUpdateCoordinator
+from .helpers import build_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,13 +57,7 @@ class IcecoBatterySensor(CoordinatorEntity[IcecoDataUpdateCoordinator], SensorEn
         self._attr_unique_id = f"{entry.data[CONF_DEVICE_ADDRESS]}_{ENTITY_BATTERY_VOLTAGE}"
         self._attr_name = "Battery Voltage"
 
-        # Device info
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.data[CONF_DEVICE_ADDRESS])},
-            name="Iceco Refrigerator",
-            manufacturer="Iceco",
-            model="Dual Zone Refrigerator",
-        )
+        self._attr_device_info = build_device_info(entry.data[CONF_DEVICE_ADDRESS])
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/iceco/switch.py
+++ b/custom_components/iceco/switch.py
@@ -7,7 +7,7 @@ from typing import Any
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -20,6 +20,7 @@ from .const import (
     ENTITY_POWER_SWITCH,
 )
 from .coordinator import IcecoDataUpdateCoordinator
+from .helpers import build_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,13 +60,7 @@ class IcecoPowerSwitch(CoordinatorEntity[IcecoDataUpdateCoordinator], SwitchEnti
         self._attr_unique_id = f"{entry.data[CONF_DEVICE_ADDRESS]}_{ENTITY_POWER_SWITCH}"
         self._attr_name = "Power"
 
-        # Device info
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.data[CONF_DEVICE_ADDRESS])},
-            name="Iceco Refrigerator",
-            manufacturer="Iceco",
-            model="Dual Zone Refrigerator",
-        )
+        self._attr_device_info = build_device_info(entry.data[CONF_DEVICE_ADDRESS])
 
     @property
     def is_on(self) -> bool | None:
@@ -123,13 +118,7 @@ class IcecoEcoModeSwitch(CoordinatorEntity[IcecoDataUpdateCoordinator], SwitchEn
         self._attr_unique_id = f"{entry.data[CONF_DEVICE_ADDRESS]}_{ENTITY_ECO_MODE}"
         self._attr_name = "ECO Mode"
 
-        # Device info
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.data[CONF_DEVICE_ADDRESS])},
-            name="Iceco Refrigerator",
-            manufacturer="Iceco",
-            model="Dual Zone Refrigerator",
-        )
+        self._attr_device_info = build_device_info(entry.data[CONF_DEVICE_ADDRESS])
 
     @property
     def is_on(self) -> bool | None:
@@ -171,13 +160,7 @@ class IcecoLockSwitch(CoordinatorEntity[IcecoDataUpdateCoordinator], SwitchEntit
         self._attr_unique_id = f"{entry.data[CONF_DEVICE_ADDRESS]}_{ENTITY_LOCK}"
         self._attr_name = "Control Panel Lock"
 
-        # Device info
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.data[CONF_DEVICE_ADDRESS])},
-            name="Iceco Refrigerator",
-            manufacturer="Iceco",
-            model="Dual Zone Refrigerator",
-        )
+        self._attr_device_info = build_device_info(entry.data[CONF_DEVICE_ADDRESS])
 
     @property
     def is_on(self) -> bool | None:
@@ -220,13 +203,7 @@ class IcecoConnectionSwitch(CoordinatorEntity[IcecoDataUpdateCoordinator], Switc
         self._attr_unique_id = f"{entry.data[CONF_DEVICE_ADDRESS]}_{ENTITY_CONNECTION}"
         self._attr_name = "BLE Connection"
 
-        # Device info
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.data[CONF_DEVICE_ADDRESS])},
-            name="Iceco Refrigerator",
-            manufacturer="Iceco",
-            model="Dual Zone Refrigerator",
-        )
+        self._attr_device_info = build_device_info(entry.data[CONF_DEVICE_ADDRESS])
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
## Summary

Six entity constructors across `climate.py`, `sensor.py`, `binary_sensor.py`, and `switch.py` each contained an identical `DeviceInfo` block. Centralises this in `helpers.py:build_device_info()` and updates all call sites.

## Test plan

- [ ] Verify all 11 entities still appear correctly in HA after reload