### PR TITLE
Migrate to entry.runtime_data and pass entry to coordinator

### DIFF
--- a/custom_components/iceco/__init__.py
+++ b/custom_components/iceco/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import CONF_DEVICE_ADDRESS, DOMAIN
+from .const import CONF_DEVICE_ADDRESS
 from .coordinator import IcecoDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,18 +40,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     # Create coordinator
-    coordinator = IcecoDataUpdateCoordinator(hass, ble_device, entry.entry_id)
+    coordinator = IcecoDataUpdateCoordinator(hass, ble_device, entry)
 
-    # Perform initial connection and data fetch
-    try:
-        await coordinator.async_config_entry_first_refresh()
-    except Exception as err:
-        _LOGGER.error("Failed to setup Iceco integration: %s", err)
-        raise ConfigEntryNotReady(f"Failed to connect to refrigerator: {err}")
+    # Register cleanup before first refresh so it always runs on unload
+    entry.async_on_unload(coordinator.async_shutdown)
 
-    # Store coordinator
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    # Perform initial connection and data fetch; raises ConfigEntryNotReady on failure
+    await coordinator.async_config_entry_first_refresh()
+
+    # Store coordinator on the entry (modern pattern — avoids hass.data globals)
+    entry.runtime_data = coordinator
 
     # Forward entry setup to platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -66,16 +64,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     _LOGGER.debug("Unloading Iceco integration")
-
-    # Unload platforms
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-    if unload_ok:
-        # Cleanup coordinator
-        coordinator: IcecoDataUpdateCoordinator = hass.data[DOMAIN].pop(entry.entry_id)
-        await coordinator.async_shutdown()
-
-    return unload_ok
+    # Coordinator shutdown is handled by the async_on_unload callback registered at setup
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/iceco/binary_sensor.py
+++ b/custom_components/iceco/binary_sensor.py
@@ -42,7 +42,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Iceco binary sensor entities from a config entry."""
-    coordinator: IcecoDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: IcecoDataUpdateCoordinator = entry.runtime_data
 
     async_add_entities(
         [

--- a/custom_components/iceco/climate.py
+++ b/custom_components/iceco/climate.py
@@ -37,7 +37,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Iceco climate entities from a config entry."""
-    coordinator: IcecoDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: IcecoDataUpdateCoordinator = entry.runtime_data
 
     async_add_entities(
         [

--- a/custom_components/iceco/coordinator.py
+++ b/custom_components/iceco/coordinator.py
@@ -14,6 +14,7 @@ from bleak_retry_connector import (
 )
 
 from homeassistant.components import bluetooth
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -79,7 +80,7 @@ class IcecoDataUpdateCoordinator(DataUpdateCoordinator[IcecoData]):
         self,
         hass: HomeAssistant,
         ble_device: BLEDevice,
-        entry_id: str,
+        entry: ConfigEntry,
     ) -> None:
         """Initialize coordinator."""
         super().__init__(
@@ -87,13 +88,12 @@ class IcecoDataUpdateCoordinator(DataUpdateCoordinator[IcecoData]):
             _LOGGER,
             name=DOMAIN,
             update_interval=timedelta(
-                seconds=hass.config_entries.async_get_entry(entry_id)
-                .options.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)
+                seconds=entry.options.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)
             ),
         )
 
         self._ble_device = ble_device
-        self._entry_id = entry_id
+        self._entry = entry
         self._client: Optional[BleakClientWithServiceCache] = None
         self._reconnect_task: Optional[asyncio.Task] = None
         self._reconnect_count = 0
@@ -109,8 +109,7 @@ class IcecoDataUpdateCoordinator(DataUpdateCoordinator[IcecoData]):
     @property
     def _options(self) -> dict:
         """Get current options from config entry."""
-        entry = self.hass.config_entries.async_get_entry(self._entry_id)
-        return entry.options if entry else {}
+        return self._entry.options
 
     async def _async_setup(self) -> None:
         """Set up the coordinator - called once on entry setup."""

--- a/custom_components/iceco/sensor.py
+++ b/custom_components/iceco/sensor.py
@@ -33,7 +33,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Iceco sensor entities from a config entry."""
-    coordinator: IcecoDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: IcecoDataUpdateCoordinator = entry.runtime_data
 
     async_add_entities([IcecoBatterySensor(coordinator, entry)])
 

--- a/custom_components/iceco/switch.py
+++ b/custom_components/iceco/switch.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Iceco switch entities from a config entry."""
-    coordinator: IcecoDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: IcecoDataUpdateCoordinator = entry.runtime_data
 
     async_add_entities(
         [


### PR DESCRIPTION
## Summary

- Replaces `hass.data[DOMAIN]` global storage with `entry.runtime_data` per current HA best practice
- Passes `ConfigEntry` directly to `IcecoDataUpdateCoordinator` instead of looking it up by ID on every poll
- Registers `coordinator.async_shutdown` via `entry.async_on_unload` for clean teardown
- Removes redundant `try/except` wrapping `async_config_entry_first_refresh` in `async_setup_entry`

## Test plan

- [ ] Reload integration and verify all entities recover correctly
- [ ] Restart HA and confirm setup completes without errors